### PR TITLE
Correct paths, add zsh path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ location doesn't matter much.
 To enable VirtualCandy, you just source it in your ~/.bashrc file. Add the
 following line into your ~/.bashrc file:
 
-    . ~/.virtualcandy/virtualcandy.sh
+    . ~/.virtualcandy/src/virtualcandy.sh
+
+or add the following line to your ~/.zshrc, as appropriate:
+
+    . ~/.virtualcandy/src/virtualcandy.zsh
 
 That's it, VirtualCandy is installed!
 


### PR DESCRIPTION
`README.md` listed `~/.virtualcandy/virtualcandy.sh` as the shell filed to be sourced, but I believe that's an old path as the file currently resides in `~/.virtualcandy/src/virtualcandy.sh`. Additionally I also added a mention to the `README.md` that there is a different shell file to source if you're using ZShell.
